### PR TITLE
add batch processing option to process_h5ad.py

### DIFF
--- a/bin/process_h5ad.py
+++ b/bin/process_h5ad.py
@@ -122,10 +122,11 @@ def batch_process_csr(file, zarr_file, m, n, batch_size, chunk_size):
 
     with h5py.File(file, "r") as f:
         indptr = f["X"]["indptr"][:]
-        for i in range(len(indptr) // batch_size + 1):
+        batch_size = len(indptr) if batch_size > len(indptr) else batch_size
+        for i in range(len(indptr) // batch_size):
             j = i * batch_size
-            if j + batch_size >= len(indptr):
-                batch_size = len(indptr) % batch_size - 1
+            if j + batch_size > len(indptr) - 1:
+                batch_size = len(indptr) - 1 - j
             k = j + batch_size
 
             indices = f["X"]["indices"][indptr[j] : indptr[k]]
@@ -146,10 +147,11 @@ def batch_process_csc(file, zarr_file, m, n, batch_size, chunk_size):
 
     with h5py.File(file, "r") as f:
         indptr = f["X"]["indptr"][:]
-        for i in range(len(indptr) // batch_size + 1):
+        batch_size = len(indptr) if batch_size > len(indptr) else batch_size
+        for i in range(len(indptr) // batch_size):
             j = i * batch_size
-            if j + batch_size >= len(indptr):
-                batch_size = len(indptr) % batch_size - 1
+            if j + batch_size > len(indptr) - 1:
+                batch_size = len(indptr) - 1 - j
             k = j + batch_size
 
             indices = f["X"]["indices"][indptr[j] : indptr[k]]
@@ -171,8 +173,8 @@ def batch_process_array(file, zarr_file, m, n, batch_size, chunk_size):
     with h5py.File(file, "r") as f:
         for i in range(n // batch_size + 1):
             j = i * batch_size
-            if j + batch_size >= n:
-                batch_size = n % batch_size
+            if j + batch_size > n:
+                batch_size = n - j
             k = j + batch_size
 
             matrix = f["X"][:, j:k]

--- a/bin/process_h5ad.py
+++ b/bin/process_h5ad.py
@@ -119,7 +119,6 @@ def h5ad_to_zarr(
 def batch_process_csr(file, zarr_file, m, n, batch_size, chunk_size):
     z = zarr.open(zarr_file, mode="a")
     z["X"] = zarr.empty((0, n), chunks=(m, chunk_size), dtype="float32")
-<<<<<<< HEAD
     with h5py.File(file, "r") as f:
         indptr = f["X"]["indptr"][:]
         batch_size = m if batch_size > m else batch_size
@@ -127,26 +126,13 @@ def batch_process_csr(file, zarr_file, m, n, batch_size, chunk_size):
             j = i * batch_size
             if j + batch_size > m:
                 batch_size = m - j
-=======
-
-    with h5py.File(file, "r") as f:
-        indptr = f["X"]["indptr"][:]
-        for i in range(len(indptr) // batch_size + 1):
-            j = i * batch_size
-            if j + batch_size >= len(indptr):
-                batch_size = len(indptr) % batch_size - 1
->>>>>>> 5e71f51 (add batch processing option to process_h5ad.py)
             k = j + batch_size
 
             indices = f["X"]["indices"][indptr[j] : indptr[k]]
             data = f["X"]["data"][indptr[j] : indptr[k]]
 
             matrix = csr_matrix(
-<<<<<<< HEAD
                 (data, indices, indptr[j:k+1]-indptr[j]),
-=======
-                (data, indices, [x - indptr[j] for x in indptr[j : k + 1]]),
->>>>>>> 5e71f51 (add batch processing option to process_h5ad.py)
                 shape=(1 * batch_size, n),
             )
 
@@ -160,29 +146,18 @@ def batch_process_csc(file, zarr_file, m, n, batch_size, chunk_size):
 
     with h5py.File(file, "r") as f:
         indptr = f["X"]["indptr"][:]
-<<<<<<< HEAD
         batch_size = n if batch_size > n else batch_size
         for i in range(n // batch_size + 1):
             j = i * batch_size
             if j + batch_size > n:
                 batch_size = n - j
-=======
-        for i in range(len(indptr) // batch_size + 1):
-            j = i * batch_size
-            if j + batch_size >= len(indptr):
-                batch_size = len(indptr) % batch_size - 1
->>>>>>> 5e71f51 (add batch processing option to process_h5ad.py)
             k = j + batch_size
 
             indices = f["X"]["indices"][indptr[j] : indptr[k]]
             data = f["X"]["data"][indptr[j] : indptr[k]]
 
             matrix = csc_matrix(
-<<<<<<< HEAD
                 (data, indices, indptr[j:k+1]-indptr[j]),
-=======
-                (data, indices, [x - indptr[j] for x in indptr[j : k + 1]]),
->>>>>>> 5e71f51 (add batch processing option to process_h5ad.py)
                 shape=(m, 1 * batch_size),
             )
 
@@ -197,13 +172,8 @@ def batch_process_array(file, zarr_file, m, n, batch_size, chunk_size):
     with h5py.File(file, "r") as f:
         for i in range(n // batch_size + 1):
             j = i * batch_size
-<<<<<<< HEAD
             if j + batch_size > n:
                 batch_size = n - j
-=======
-            if j + batch_size >= n:
-                batch_size = n % batch_size
->>>>>>> 5e71f51 (add batch processing option to process_h5ad.py)
             k = j + batch_size
 
             matrix = f["X"][:, j:k]

--- a/bin/process_h5ad.py
+++ b/bin/process_h5ad.py
@@ -132,7 +132,7 @@ def batch_process_csr(file, zarr_file, m, n, batch_size, chunk_size):
             data = f["X"]["data"][indptr[j] : indptr[k]]
 
             matrix = csr_matrix(
-                (data, indices, indptr[j:k+1]-indptr[j]),
+                (data, indices, indptr[j : k + 1] - indptr[j]),
                 shape=(1 * batch_size, n),
             )
 
@@ -157,7 +157,7 @@ def batch_process_csc(file, zarr_file, m, n, batch_size, chunk_size):
             data = f["X"]["data"][indptr[j] : indptr[k]]
 
             matrix = csc_matrix(
-                (data, indices, indptr[j:k+1]-indptr[j]),
+                (data, indices, indptr[j : k + 1] - indptr[j]),
                 shape=(m, 1 * batch_size),
             )
 

--- a/bin/process_h5ad.py
+++ b/bin/process_h5ad.py
@@ -119,6 +119,7 @@ def h5ad_to_zarr(
 def batch_process_csr(file, zarr_file, m, n, batch_size, chunk_size):
     z = zarr.open(zarr_file, mode="a")
     z["X"] = zarr.empty((0, n), chunks=(m, chunk_size), dtype="float32")
+<<<<<<< HEAD
     with h5py.File(file, "r") as f:
         indptr = f["X"]["indptr"][:]
         batch_size = m if batch_size > m else batch_size
@@ -126,13 +127,26 @@ def batch_process_csr(file, zarr_file, m, n, batch_size, chunk_size):
             j = i * batch_size
             if j + batch_size > m:
                 batch_size = m - j
+=======
+
+    with h5py.File(file, "r") as f:
+        indptr = f["X"]["indptr"][:]
+        for i in range(len(indptr) // batch_size + 1):
+            j = i * batch_size
+            if j + batch_size >= len(indptr):
+                batch_size = len(indptr) % batch_size - 1
+>>>>>>> 5e71f51 (add batch processing option to process_h5ad.py)
             k = j + batch_size
 
             indices = f["X"]["indices"][indptr[j] : indptr[k]]
             data = f["X"]["data"][indptr[j] : indptr[k]]
 
             matrix = csr_matrix(
+<<<<<<< HEAD
                 (data, indices, indptr[j:k+1]-indptr[j]),
+=======
+                (data, indices, [x - indptr[j] for x in indptr[j : k + 1]]),
+>>>>>>> 5e71f51 (add batch processing option to process_h5ad.py)
                 shape=(1 * batch_size, n),
             )
 
@@ -146,18 +160,29 @@ def batch_process_csc(file, zarr_file, m, n, batch_size, chunk_size):
 
     with h5py.File(file, "r") as f:
         indptr = f["X"]["indptr"][:]
+<<<<<<< HEAD
         batch_size = n if batch_size > n else batch_size
         for i in range(n // batch_size + 1):
             j = i * batch_size
             if j + batch_size > n:
                 batch_size = n - j
+=======
+        for i in range(len(indptr) // batch_size + 1):
+            j = i * batch_size
+            if j + batch_size >= len(indptr):
+                batch_size = len(indptr) % batch_size - 1
+>>>>>>> 5e71f51 (add batch processing option to process_h5ad.py)
             k = j + batch_size
 
             indices = f["X"]["indices"][indptr[j] : indptr[k]]
             data = f["X"]["data"][indptr[j] : indptr[k]]
 
             matrix = csc_matrix(
+<<<<<<< HEAD
                 (data, indices, indptr[j:k+1]-indptr[j]),
+=======
+                (data, indices, [x - indptr[j] for x in indptr[j : k + 1]]),
+>>>>>>> 5e71f51 (add batch processing option to process_h5ad.py)
                 shape=(m, 1 * batch_size),
             )
 
@@ -172,8 +197,13 @@ def batch_process_array(file, zarr_file, m, n, batch_size, chunk_size):
     with h5py.File(file, "r") as f:
         for i in range(n // batch_size + 1):
             j = i * batch_size
+<<<<<<< HEAD
             if j + batch_size > n:
                 batch_size = n - j
+=======
+            if j + batch_size >= n:
+                batch_size = n % batch_size
+>>>>>>> 5e71f51 (add batch processing option to process_h5ad.py)
             k = j + batch_size
 
             matrix = f["X"][:, j:k]

--- a/docker/Dockerfile.processing
+++ b/docker/Dockerfile.processing
@@ -7,4 +7,4 @@ RUN apt-get update && \
 
 RUN python3 -m pip install --upgrade pip --no-cache-dir
 
-RUN pip3 install scanpy anndata zarr fire ome-zarr
+RUN pip3 install numpy pandas h5py scipy anndata scanpy zarr fire

--- a/tests/test_class.py
+++ b/tests/test_class.py
@@ -167,44 +167,6 @@ class TestClass:
         z = zarr.open(out_file, mode="r")
         assert np.array_equal(z_batch["X"], z["X"])
 
-    def test_csr_h5ad_to_zarr(self, monkeypatch, anndata_csr_h5ad_file):
-        monkeypatch.chdir(os.path.dirname(anndata_csr_h5ad_file))
-        stem = "test"
-        out_file = h5ad_to_zarr(anndata_csr_h5ad_file, stem)
-        assert os.path.exists(out_file)
-        z = zarr.open(out_file, mode="r")
-        assert "X" in z and isinstance(z["X"], zarr.Array)
-        assert "obs" in z
-        assert "var" in z
-        assert "obsm" in z and "spatial" in z["obsm"]
-        assert "uns" in z and "spatial" in z["uns"]
-        assert out_file == stem + "_anndata.zarr"
-
-    def test_batch_csr_h5ad_to_zarr(self, monkeypatch, anndata_csr_h5ad_file):
-        monkeypatch.chdir(os.path.dirname(anndata_csr_h5ad_file))
-        stem = "batch_test"
-        out_batch_file = h5ad_to_zarr(
-            anndata_csr_h5ad_file, stem, batch_processing=True, batch_size=2
-        )
-        assert out_batch_file == stem + "_anndata.zarr"
-
-    def test_batch_h5ad_to_zarr(self, monkeypatch, anndata_h5ad_file):
-        monkeypatch.chdir(os.path.dirname(anndata_h5ad_file))
-        stem = "batch_test"
-        out_batch_file = h5ad_to_zarr(anndata_h5ad_file, stem, batch_processing=True, batch_size=2)
-        assert os.path.exists(out_batch_file)
-        assert out_batch_file == stem + "_anndata.zarr"
-        z_batch = zarr.open(out_batch_file, mode="r")
-        assert "X" in z_batch and isinstance(z_batch["X"], zarr.Array)
-        assert "obs" in z_batch
-        assert "var" in z_batch
-        assert "obsm" in z_batch and "spatial" in z_batch["obsm"]
-        assert "uns" in z_batch and "spatial" in z_batch["uns"]
-        stem = "test"
-        out_file = h5ad_to_zarr(anndata_h5ad_file, stem)
-        z = zarr.open(out_file, mode="r")
-        assert np.array_equal(z_batch["X"], z["X"])
-
     def test_csc_h5ad_to_zarr(self, monkeypatch, anndata_csc_h5ad_file):
         monkeypatch.chdir(os.path.dirname(anndata_csc_h5ad_file))
         stem = "test"
@@ -223,7 +185,6 @@ class TestClass:
         stem = "batch_test"
         out_batch_file = h5ad_to_zarr(
             anndata_csc_h5ad_file, stem, batch_processing=True, batch_size=4
-
         )
         assert os.path.exists(out_batch_file)
         assert out_batch_file == stem + "_anndata.zarr"
@@ -267,38 +228,6 @@ class TestClass:
         assert "uns" in z_batch and "spatial" in z_batch["uns"]
         stem = "test"
         out_file = h5ad_to_zarr(anndata_csr_h5ad_file, stem)
-        z = zarr.open(out_file, mode="r")
-        assert np.array_equal(z_batch["X"], z["X"])
-
-    def test_csc_h5ad_to_zarr(self, monkeypatch, anndata_csc_h5ad_file):
-        monkeypatch.chdir(os.path.dirname(anndata_csc_h5ad_file))
-        stem = "test"
-        out_file = h5ad_to_zarr(anndata_csc_h5ad_file, stem)
-        assert os.path.exists(out_file)
-        z = zarr.open(out_file, mode="r")
-        assert "X" in z and isinstance(z["X"], zarr.Array)
-        assert "obs" in z
-        assert "var" in z
-        assert "obsm" in z and "spatial" in z["obsm"]
-        assert "uns" in z and "spatial" in z["uns"]
-        assert out_file == stem + "_anndata.zarr"
-
-    def test_batch_csc_h5ad_to_zarr(self, monkeypatch, anndata_csc_h5ad_file):
-        monkeypatch.chdir(os.path.dirname(anndata_csc_h5ad_file))
-        stem = "batch_test"
-        out_batch_file = h5ad_to_zarr(
-            anndata_csc_h5ad_file, stem, batch_processing=True, batch_size=4
-        )
-        assert os.path.exists(out_batch_file)
-        assert out_batch_file == stem + "_anndata.zarr"
-        z_batch = zarr.open(out_batch_file, mode="r")
-        assert "X" in z_batch and isinstance(z_batch["X"], zarr.Array)
-        assert "obs" in z_batch
-        assert "var" in z_batch
-        assert "obsm" in z_batch and "spatial" in z_batch["obsm"]
-        assert "uns" in z_batch and "spatial" in z_batch["uns"]
-        stem = "test"
-        out_file = h5ad_to_zarr(anndata_csc_h5ad_file, stem)
         z = zarr.open(out_file, mode="r")
         assert np.array_equal(z_batch["X"], z["X"])
 

--- a/tests/test_class.py
+++ b/tests/test_class.py
@@ -8,7 +8,9 @@ from xml.etree.ElementTree import ElementTree
 import xmlschema
 import zarr
 import numpy as np
+import pandas as pd
 import anndata as ad
+from scipy.sparse import csc_matrix, csr_matrix
 
 from bin.process_h5ad import h5ad_to_zarr
 from bin.process_molecules import tsv_to_json
@@ -23,7 +25,44 @@ from bin.generate_label import main as generate_label
 class TestClass:
     @pytest.fixture(scope="class")
     def anndata_h5ad_file(self, tmp_path_factory):
-        adata = ad.AnnData(np.array([[100.0] * 3] * 3), dtype=float)
+        adata = ad.AnnData(
+            np.array([[100.0] * 4] * 3),
+            obs=pd.DataFrame(index=["obs1", "obs2", "obs3"]),
+            var=pd.DataFrame(index=["var1", "var2", "var3", "var4"]),
+            dtype="float32",
+        )
+        adata.uns["spatial"] = {
+            "anndata": {"scalefactors": {"spot_diameter_fullres": 10}}
+        }
+        adata.obsm["spatial"] = np.array([[20.0, 20.0], [40.0, 40.0], [60.0, 60.0]])
+        fn = tmp_path_factory.mktemp("data") / "anndata.h5ad"
+        adata.write_h5ad(fn)
+        return fn
+
+    @pytest.fixture(scope="class")
+    def anndata_csr_h5ad_file(self, tmp_path_factory):
+        adata = ad.AnnData(
+            csr_matrix(np.array([[100.0] * 4] * 3)),
+            obs=pd.DataFrame(index=["obs1", "obs2", "obs3"]),
+            var=pd.DataFrame(index=["var1", "var2", "var3", "var4"]),
+            dtype="float32",
+        )
+        adata.uns["spatial"] = {
+            "anndata": {"scalefactors": {"spot_diameter_fullres": 10}}
+        }
+        adata.obsm["spatial"] = np.array([[20.0, 20.0], [40.0, 40.0], [60.0, 60.0]])
+        fn = tmp_path_factory.mktemp("data") / "anndata.h5ad"
+        adata.write_h5ad(fn)
+        return fn
+
+    @pytest.fixture(scope="class")
+    def anndata_csc_h5ad_file(self, tmp_path_factory):
+        adata = ad.AnnData(
+            csc_matrix(np.array([[100.0] * 4] * 3)),
+            obs=pd.DataFrame(index=["obs1", "obs2", "obs3"]),
+            var=pd.DataFrame(index=["var1", "var2", "var3", "var4"]),
+            dtype="float32",
+        )
         adata.uns["spatial"] = {
             "anndata": {"scalefactors": {"spot_diameter_fullres": 10}}
         }
@@ -112,7 +151,9 @@ class TestClass:
     def test_batch_h5ad_to_zarr(self, monkeypatch, anndata_h5ad_file):
         monkeypatch.chdir(os.path.dirname(anndata_h5ad_file))
         stem = "batch_test"
-        out_batch_file = h5ad_to_zarr(anndata_h5ad_file, stem, batch_processing=True, batch_size=2)
+        out_batch_file = h5ad_to_zarr(
+            anndata_h5ad_file, stem, batch_processing=True, batch_size=2
+        )
         assert os.path.exists(out_batch_file)
         assert out_batch_file == stem + "_anndata.zarr"
         z_batch = zarr.open(out_batch_file, mode="r")
@@ -123,6 +164,70 @@ class TestClass:
         assert "uns" in z_batch and "spatial" in z_batch["uns"]
         stem = "test"
         out_file = h5ad_to_zarr(anndata_h5ad_file, stem)
+        z = zarr.open(out_file, mode="r")
+        assert np.array_equal(z_batch["X"], z["X"])
+
+    def test_csr_h5ad_to_zarr(self, monkeypatch, anndata_csr_h5ad_file):
+        monkeypatch.chdir(os.path.dirname(anndata_csr_h5ad_file))
+        stem = "test"
+        out_file = h5ad_to_zarr(anndata_csr_h5ad_file, stem)
+        assert os.path.exists(out_file)
+        z = zarr.open(out_file, mode="r")
+        assert "X" in z and isinstance(z["X"], zarr.Array)
+        assert "obs" in z
+        assert "var" in z
+        assert "obsm" in z and "spatial" in z["obsm"]
+        assert "uns" in z and "spatial" in z["uns"]
+        assert out_file == stem + "_anndata.zarr"
+
+    def test_batch_csr_h5ad_to_zarr(self, monkeypatch, anndata_csr_h5ad_file):
+        monkeypatch.chdir(os.path.dirname(anndata_csr_h5ad_file))
+        stem = "batch_test"
+        out_batch_file = h5ad_to_zarr(
+            anndata_csr_h5ad_file, stem, batch_processing=True, batch_size=2
+        )
+        assert os.path.exists(out_batch_file)
+        assert out_batch_file == stem + "_anndata.zarr"
+        z_batch = zarr.open(out_batch_file, mode="r")
+        assert "X" in z_batch and isinstance(z_batch["X"], zarr.Array)
+        assert "obs" in z_batch
+        assert "var" in z_batch
+        assert "obsm" in z_batch and "spatial" in z_batch["obsm"]
+        assert "uns" in z_batch and "spatial" in z_batch["uns"]
+        stem = "test"
+        out_file = h5ad_to_zarr(anndata_csr_h5ad_file, stem)
+        z = zarr.open(out_file, mode="r")
+        assert np.array_equal(z_batch["X"], z["X"])
+
+    def test_csc_h5ad_to_zarr(self, monkeypatch, anndata_csc_h5ad_file):
+        monkeypatch.chdir(os.path.dirname(anndata_csc_h5ad_file))
+        stem = "test"
+        out_file = h5ad_to_zarr(anndata_csc_h5ad_file, stem)
+        assert os.path.exists(out_file)
+        z = zarr.open(out_file, mode="r")
+        assert "X" in z and isinstance(z["X"], zarr.Array)
+        assert "obs" in z
+        assert "var" in z
+        assert "obsm" in z and "spatial" in z["obsm"]
+        assert "uns" in z and "spatial" in z["uns"]
+        assert out_file == stem + "_anndata.zarr"
+
+    def test_batch_csc_h5ad_to_zarr(self, monkeypatch, anndata_csc_h5ad_file):
+        monkeypatch.chdir(os.path.dirname(anndata_csc_h5ad_file))
+        stem = "batch_test"
+        out_batch_file = h5ad_to_zarr(
+            anndata_csc_h5ad_file, stem, batch_processing=True, batch_size=4
+        )
+        assert os.path.exists(out_batch_file)
+        assert out_batch_file == stem + "_anndata.zarr"
+        z_batch = zarr.open(out_batch_file, mode="r")
+        assert "X" in z_batch and isinstance(z_batch["X"], zarr.Array)
+        assert "obs" in z_batch
+        assert "var" in z_batch
+        assert "obsm" in z_batch and "spatial" in z_batch["obsm"]
+        assert "uns" in z_batch and "spatial" in z_batch["uns"]
+        stem = "test"
+        out_file = h5ad_to_zarr(anndata_csc_h5ad_file, stem)
         z = zarr.open(out_file, mode="r")
         assert np.array_equal(z_batch["X"], z["X"])
 

--- a/tests/test_class.py
+++ b/tests/test_class.py
@@ -146,6 +146,7 @@ class TestClass:
         assert "var" in z
         assert "obsm" in z and "spatial" in z["obsm"]
         assert "uns" in z and "spatial" in z["uns"]
+<<<<<<< HEAD
         assert out_file == stem + "_anndata.zarr"
 
     def test_batch_h5ad_to_zarr(self, monkeypatch, anndata_h5ad_file):
@@ -186,6 +187,14 @@ class TestClass:
         out_batch_file = h5ad_to_zarr(
             anndata_csr_h5ad_file, stem, batch_processing=True, batch_size=2
         )
+=======
+        assert out_file == stem + "_anndata.zarr"
+
+    def test_batch_h5ad_to_zarr(self, monkeypatch, anndata_h5ad_file):
+        monkeypatch.chdir(os.path.dirname(anndata_h5ad_file))
+        stem = "batch_test"
+        out_batch_file = h5ad_to_zarr(anndata_h5ad_file, stem, batch_processing=True, batch_size=2)
+>>>>>>> e349376 (add test case for batch processing h5ad)
         assert os.path.exists(out_batch_file)
         assert out_batch_file == stem + "_anndata.zarr"
         z_batch = zarr.open(out_batch_file, mode="r")
@@ -195,6 +204,7 @@ class TestClass:
         assert "obsm" in z_batch and "spatial" in z_batch["obsm"]
         assert "uns" in z_batch and "spatial" in z_batch["uns"]
         stem = "test"
+<<<<<<< HEAD
         out_file = h5ad_to_zarr(anndata_csr_h5ad_file, stem)
         z = zarr.open(out_file, mode="r")
         assert np.array_equal(z_batch["X"], z["X"])
@@ -228,6 +238,9 @@ class TestClass:
         assert "uns" in z_batch and "spatial" in z_batch["uns"]
         stem = "test"
         out_file = h5ad_to_zarr(anndata_csc_h5ad_file, stem)
+=======
+        out_file = h5ad_to_zarr(anndata_h5ad_file, stem)
+>>>>>>> e349376 (add test case for batch processing h5ad)
         z = zarr.open(out_file, mode="r")
         assert np.array_equal(z_batch["X"], z["X"])
 

--- a/tests/test_class.py
+++ b/tests/test_class.py
@@ -193,6 +193,7 @@ class TestClass:
     def test_batch_h5ad_to_zarr(self, monkeypatch, anndata_h5ad_file):
         monkeypatch.chdir(os.path.dirname(anndata_h5ad_file))
         stem = "batch_test"
+<<<<<<< HEAD
         out_batch_file = h5ad_to_zarr(anndata_h5ad_file, stem, batch_processing=True, batch_size=2)
 >>>>>>> e349376 (add test case for batch processing h5ad)
         assert os.path.exists(out_batch_file)
@@ -227,6 +228,10 @@ class TestClass:
         stem = "batch_test"
         out_batch_file = h5ad_to_zarr(
             anndata_csc_h5ad_file, stem, batch_processing=True, batch_size=4
+=======
+        out_batch_file = h5ad_to_zarr(
+            anndata_h5ad_file, stem, batch_processing=True, batch_size=2
+>>>>>>> 0c83145 (fix batch processing)
         )
         assert os.path.exists(out_batch_file)
         assert out_batch_file == stem + "_anndata.zarr"
@@ -241,6 +246,70 @@ class TestClass:
 =======
         out_file = h5ad_to_zarr(anndata_h5ad_file, stem)
 >>>>>>> e349376 (add test case for batch processing h5ad)
+        z = zarr.open(out_file, mode="r")
+        assert np.array_equal(z_batch["X"], z["X"])
+
+    def test_csr_h5ad_to_zarr(self, monkeypatch, anndata_csr_h5ad_file):
+        monkeypatch.chdir(os.path.dirname(anndata_csr_h5ad_file))
+        stem = "test"
+        out_file = h5ad_to_zarr(anndata_csr_h5ad_file, stem)
+        assert os.path.exists(out_file)
+        z = zarr.open(out_file, mode="r")
+        assert "X" in z and isinstance(z["X"], zarr.Array)
+        assert "obs" in z
+        assert "var" in z
+        assert "obsm" in z and "spatial" in z["obsm"]
+        assert "uns" in z and "spatial" in z["uns"]
+        assert out_file == stem + "_anndata.zarr"
+
+    def test_batch_csr_h5ad_to_zarr(self, monkeypatch, anndata_csr_h5ad_file):
+        monkeypatch.chdir(os.path.dirname(anndata_csr_h5ad_file))
+        stem = "batch_test"
+        out_batch_file = h5ad_to_zarr(
+            anndata_csr_h5ad_file, stem, batch_processing=True, batch_size=2
+        )
+        assert os.path.exists(out_batch_file)
+        assert out_batch_file == stem + "_anndata.zarr"
+        z_batch = zarr.open(out_batch_file, mode="r")
+        assert "X" in z_batch and isinstance(z_batch["X"], zarr.Array)
+        assert "obs" in z_batch
+        assert "var" in z_batch
+        assert "obsm" in z_batch and "spatial" in z_batch["obsm"]
+        assert "uns" in z_batch and "spatial" in z_batch["uns"]
+        stem = "test"
+        out_file = h5ad_to_zarr(anndata_csr_h5ad_file, stem)
+        z = zarr.open(out_file, mode="r")
+        assert np.array_equal(z_batch["X"], z["X"])
+
+    def test_csc_h5ad_to_zarr(self, monkeypatch, anndata_csc_h5ad_file):
+        monkeypatch.chdir(os.path.dirname(anndata_csc_h5ad_file))
+        stem = "test"
+        out_file = h5ad_to_zarr(anndata_csc_h5ad_file, stem)
+        assert os.path.exists(out_file)
+        z = zarr.open(out_file, mode="r")
+        assert "X" in z and isinstance(z["X"], zarr.Array)
+        assert "obs" in z
+        assert "var" in z
+        assert "obsm" in z and "spatial" in z["obsm"]
+        assert "uns" in z and "spatial" in z["uns"]
+        assert out_file == stem + "_anndata.zarr"
+
+    def test_batch_csc_h5ad_to_zarr(self, monkeypatch, anndata_csc_h5ad_file):
+        monkeypatch.chdir(os.path.dirname(anndata_csc_h5ad_file))
+        stem = "batch_test"
+        out_batch_file = h5ad_to_zarr(
+            anndata_csc_h5ad_file, stem, batch_processing=True, batch_size=4
+        )
+        assert os.path.exists(out_batch_file)
+        assert out_batch_file == stem + "_anndata.zarr"
+        z_batch = zarr.open(out_batch_file, mode="r")
+        assert "X" in z_batch and isinstance(z_batch["X"], zarr.Array)
+        assert "obs" in z_batch
+        assert "var" in z_batch
+        assert "obsm" in z_batch and "spatial" in z_batch["obsm"]
+        assert "uns" in z_batch and "spatial" in z_batch["uns"]
+        stem = "test"
+        out_file = h5ad_to_zarr(anndata_csc_h5ad_file, stem)
         z = zarr.open(out_file, mode="r")
         assert np.array_equal(z_batch["X"], z["X"])
 

--- a/tests/test_class.py
+++ b/tests/test_class.py
@@ -146,7 +146,6 @@ class TestClass:
         assert "var" in z
         assert "obsm" in z and "spatial" in z["obsm"]
         assert "uns" in z and "spatial" in z["uns"]
-<<<<<<< HEAD
         assert out_file == stem + "_anndata.zarr"
 
     def test_batch_h5ad_to_zarr(self, monkeypatch, anndata_h5ad_file):
@@ -187,15 +186,12 @@ class TestClass:
         out_batch_file = h5ad_to_zarr(
             anndata_csr_h5ad_file, stem, batch_processing=True, batch_size=2
         )
-=======
-        assert out_file == stem + "_anndata.zarr"
+        assert out_batch_file == stem + "_anndata.zarr"
 
     def test_batch_h5ad_to_zarr(self, monkeypatch, anndata_h5ad_file):
         monkeypatch.chdir(os.path.dirname(anndata_h5ad_file))
         stem = "batch_test"
-<<<<<<< HEAD
         out_batch_file = h5ad_to_zarr(anndata_h5ad_file, stem, batch_processing=True, batch_size=2)
->>>>>>> e349376 (add test case for batch processing h5ad)
         assert os.path.exists(out_batch_file)
         assert out_batch_file == stem + "_anndata.zarr"
         z_batch = zarr.open(out_batch_file, mode="r")
@@ -205,8 +201,7 @@ class TestClass:
         assert "obsm" in z_batch and "spatial" in z_batch["obsm"]
         assert "uns" in z_batch and "spatial" in z_batch["uns"]
         stem = "test"
-<<<<<<< HEAD
-        out_file = h5ad_to_zarr(anndata_csr_h5ad_file, stem)
+        out_file = h5ad_to_zarr(anndata_h5ad_file, stem)
         z = zarr.open(out_file, mode="r")
         assert np.array_equal(z_batch["X"], z["X"])
 
@@ -228,10 +223,7 @@ class TestClass:
         stem = "batch_test"
         out_batch_file = h5ad_to_zarr(
             anndata_csc_h5ad_file, stem, batch_processing=True, batch_size=4
-=======
-        out_batch_file = h5ad_to_zarr(
-            anndata_h5ad_file, stem, batch_processing=True, batch_size=2
->>>>>>> 0c83145 (fix batch processing)
+
         )
         assert os.path.exists(out_batch_file)
         assert out_batch_file == stem + "_anndata.zarr"
@@ -243,9 +235,6 @@ class TestClass:
         assert "uns" in z_batch and "spatial" in z_batch["uns"]
         stem = "test"
         out_file = h5ad_to_zarr(anndata_csc_h5ad_file, stem)
-=======
-        out_file = h5ad_to_zarr(anndata_h5ad_file, stem)
->>>>>>> e349376 (add test case for batch processing h5ad)
         z = zarr.open(out_file, mode="r")
         assert np.array_equal(z_batch["X"], z["X"])
 


### PR DESCRIPTION
batch processing of h5ad to incrementally write expression matrix to zarr, avoiding loading full matrix to memory